### PR TITLE
moved go lib to dovetail-contrib repo, refactor import urls

### DIFF
--- a/blockchain/hyperledger-fabric/cntrsvc.go
+++ b/blockchain/hyperledger-fabric/cntrsvc.go
@@ -1,7 +1,7 @@
 package hyperledgerfabric
 
 import (
-	"github.com/TIBCOSoftware/dovetail-go-lib/runtime/services"
+	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/services"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 )
 

--- a/blockchain/hyperledger-fabric/txnsvc.go
+++ b/blockchain/hyperledger-fabric/txnsvc.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	//"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/utils"
+	txn "github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/transaction"
 	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/utils"
-	txn "github.com/TIBCOSoftware/dovetail-go-lib/runtime/transaction"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"github.com/hyperledger/fabric/core/chaincode/lib/cid"
 	"github.com/hyperledger/fabric/core/chaincode/shim"

--- a/smartcontract-go/activity/aggregate/activity.go
+++ b/smartcontract-go/activity/aggregate/activity.go
@@ -7,7 +7,7 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 
-	hcmath "github.com/TIBCOSoftware/dovetail-go-lib/runtime/functions/math"
+	hcmath "github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/functions/math"
 )
 
 // Constants

--- a/smartcontract-go/activity/ledger/activity.go
+++ b/smartcontract-go/activity/ledger/activity.go
@@ -8,7 +8,7 @@ import (
 	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/utils"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 
-	dtsvc "github.com/TIBCOSoftware/dovetail-go-lib/runtime/services"
+	dtsvc "github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/services"
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
 )
 

--- a/smartcontract-go/activity/mapper/activity.go
+++ b/smartcontract-go/activity/mapper/activity.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	hcmath "github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/functions/math"
 	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/utils"
-	hcmath "github.com/TIBCOSoftware/dovetail-go-lib/runtime/functions/math"
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/shopspring/decimal"

--- a/smartcontract-go/trigger/transaction/metadataParser.go
+++ b/smartcontract-go/trigger/transaction/metadataParser.go
@@ -3,8 +3,8 @@ package transaction
 import (
 	"strings"
 
+	rttxn "github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/transaction"
 	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/utils"
-	rttxn "github.com/TIBCOSoftware/dovetail-go-lib/runtime/transaction"
 	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
 )
 

--- a/smartcontract-go/trigger/transaction/trigger.go
+++ b/smartcontract-go/trigger/transaction/trigger.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/TIBCOSoftware/dovetail-go-lib/runtime/services"
+	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/services"
 
 	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/activity/txnreply"
+	rttxn "github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/transaction"
 	"github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/utils"
-	rttxn "github.com/TIBCOSoftware/dovetail-go-lib/runtime/transaction"
 	fldata "github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
@@ -94,7 +94,7 @@ func (t *TXNTrigger) Stop() error {
 	return nil
 }
 
-//Trigger must implement this function from dovetail-go-lib/runtime/trigger SmartContractTrigger interface
+//Trigger must implement this function from dovetail-contrib/smartcontract-go/runtime/trigger SmartContractTrigger interface
 func (t *TXNTrigger) Invoke(stub services.ContainerService, txn rttxn.TransactionService) (status bool, data interface{}, err error) {
 	logger.Debug("Enter trigger Invoke...")
 	defer logger.Debug("Exit trigger invoke")

--- a/smartcontract-go/utils/processData.go
+++ b/smartcontract-go/utils/processData.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	dtsvc "github.com/TIBCOSoftware/dovetail-go-lib/runtime/services"
+	dtsvc "github.com/TIBCOSoftware/dovetail-contrib/smartcontract-go/runtime/services"
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 )


### PR DESCRIPTION
specific interfaces and functions for dovetail go runtime. These interfaces should in a separate repo, due to time constraint, placed in dovetail-contrib repo for now.

- a blockchain container must implement following interfaces:

   - ContainerService
   - DataService
   - EventService
   - LogService
   - TransactionService

- a trigger must implement following interface:
   - SmartContractTrigger

- engine.go : register resources and create trigger at engine start up